### PR TITLE
Bm 78/rss

### DIFF
--- a/plugins/castiron/manifold/Plugin.php
+++ b/plugins/castiron/manifold/Plugin.php
@@ -17,6 +17,7 @@ use Castiron\Manifold\Content\MultiButtonCallout;
 use Castiron\Manifold\Content\OneButtonCallout;
 use Castiron\Manifold\Content\OneButtonHero;
 use Castiron\Manifold\Content\ParallaxCallout;
+use Castiron\Manifold\Content\Rss;
 use Castiron\Manifold\Content\ServicePackages;
 use Castiron\Manifold\Content\Testimonials;
 use Castiron\Manifold\Content\TwoColumnBlock;
@@ -231,6 +232,13 @@ class Plugin extends PluginBase
           'position' => 100,
           'category' => 'Block',
         ]);
+
+        ContentManager::registerElement(Rss::class, [
+          'icon' => 'icon-newspaper-o',
+          'label' => 'RSS Feed Items',
+          'position' => 100,
+          'category' => 'Special',
+        ]);
     }
 
     /**
@@ -286,4 +294,11 @@ class Plugin extends PluginBase
             ],
         ];
     }
+
+  public function registerSchedule($schedule)
+  {
+    $schedule->call(function () {
+      (new \Castiron\Manifold\Services\Rss())->fetchAll();
+    })->everyFiveMinutes()->name('Rss::fetchAll')->withoutOverlapping();
+  }
 }

--- a/plugins/castiron/manifold/console/FetchRss.php
+++ b/plugins/castiron/manifold/console/FetchRss.php
@@ -1,0 +1,27 @@
+<?php namespace Castiron\Manifold\Console;
+
+use Castiron\Manifold\Services\Rss;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class FetchRss extends Command {
+  /**
+   * @var string The console command name.
+   */
+  protected $name = 'rss:fetch';
+
+  /**
+   * @var string The console command description.
+   */
+  protected $description = 'Fetches all RSS feeds';
+
+  /**
+   * Execute the console command.
+   * @return void
+   */
+  public function handle()
+  {
+    (new Rss())->fetchAll();
+  }
+}

--- a/plugins/castiron/manifold/content/Rss.php
+++ b/plugins/castiron/manifold/content/Rss.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Castiron\Manifold\Content;
+
+use Carbon\Carbon;
+use Castiron\Contentment\Content\Element;
+use Castiron\Contentment\Content\Traits\Twiggable;
+use Cache;
+
+/**
+ * Rss Element
+ */
+class Rss extends Element
+{
+  const CACHE_KEY_PREPEND = 'rss-feed';
+  const CACHE_MINUTES = 360;
+  use Twiggable;
+
+  public function getRssFeed()
+  {
+    $posts = Cache::get($this->getDataCacheKey());
+
+    $fallback = false;
+    if($posts === null) {
+      $fallback = true;
+      $posts = Cache::get($this->getFallbackCacheKey());
+    }
+
+    $expiration = Cache::get($this->getRefreshCacheKey());
+
+    $diffString = 'expired';
+
+    $now = Carbon::now();
+    if ($expiration !== null AND $expiration->gte($now)) {
+      $diffString = $expiration->diffInSeconds(Carbon::now());
+    }
+    return ['posts' => $posts, 'refresh' => $diffString, 'fallback' => $fallback];
+  }
+
+  /**
+   * @return string
+   */
+  public function getDataCacheKey()
+  {
+    return self::CACHE_KEY_PREPEND . '-' . $this->id;
+  }
+
+  /**
+   * @return string
+   */
+  public function getRefreshCacheKey()
+  {
+    return self::CACHE_KEY_PREPEND . '-refresh-' . $this->id;
+  }
+
+  /**
+   * @return string
+   */
+  public function getFallbackCacheKey()
+  {
+    return self::CACHE_KEY_PREPEND . '-fallback-' . $this->id;
+  }
+
+  /**
+   * @return int
+   */
+  public function getCacheMinutes()
+  {
+    return self::CACHE_MINUTES;
+  }
+}

--- a/plugins/castiron/manifold/content/rss/default.htm
+++ b/plugins/castiron/manifold/content/rss/default.htm
@@ -1,0 +1,22 @@
+{% set rssFeed = model.getRssFeed(feed_url, num_items) %}
+
+{% if rssFeed.posts %}
+  <section class="background-gray">
+    <div class="block blog-roll">
+      <a href="{{site_url}}" class="blog-roll-header flex-row vert-centered">
+        <span class="primary heading-secondary blog-label">Building</span><span class="heading-secondary blog-label gray">Manifold</span>
+        <i class="icon-arrow-right"></i>
+      </a>
+      <div class="flex-row blog-roll-grid">
+      <!-- expires: {{ rssFeed.refresh }} fallback: {{ rssFeed.fallback ? 'true' : 'false' }} -->
+      {% for post in rssFeed.posts %}
+        <a href="{{ post.link }}" class="col blog-post">
+          <div class="subheading-primary blog-post-title" data-mh="blog-post-name">{{ post.title }}</div>
+          <div class="copy-tertiary blog-post-summary" data-mh="blog-post-description">{{ post.description|raw }}</div>
+          <span class="blog-post-link">Read More</span>
+        </a>
+      {% endfor %}
+      </div>
+    </div>
+  </section>
+{% endif %}

--- a/plugins/castiron/manifold/content/rss/fields.yaml
+++ b/plugins/castiron/manifold/content/rss/fields.yaml
@@ -1,0 +1,11 @@
+# ===================================
+#  Form Field Definitions
+# ===================================
+
+fields:
+  site_url:
+    label: Site Url
+  feed_url:
+    label: Feed Url
+  num_items:
+    label: Number of Posts to Fetch

--- a/plugins/castiron/manifold/content/rss/preview.htm
+++ b/plugins/castiron/manifold/content/rss/preview.htm
@@ -1,0 +1,5 @@
+{% if feed_url %}
+  <p>{{ feed_url }}</p>
+{% else %}
+  <p>No Feed Url</p>
+{% endif %}

--- a/plugins/castiron/manifold/services/Rss.php
+++ b/plugins/castiron/manifold/services/Rss.php
@@ -1,0 +1,62 @@
+<?php namespace Castiron\Manifold\Services;
+
+use Carbon\Carbon;
+use Castiron\Contentment\Models\Content;
+use Illuminate\Support\Facades\Log;
+use SimpleXmlElement;
+use Cache;
+
+class Rss
+{
+  public function fetchAll()
+  {
+    $contents = Content::where('element_type', 'Castiron\\Manifold\\Content\\Rss')->whereNull('deleted_at')->get();
+
+    foreach ($contents as $content) {
+      $element = $content->element();
+
+      $data = Cache::get($element->getDataCacheKey());
+      $refresh = Cache::get($element->getRefreshCacheKey());
+
+      $now = Carbon::now();
+
+      if (($data === null) OR ($refresh === null) OR ($now->gte($refresh))) {
+        $posts = $this->getFeedData($element->feed_url, $element->num_items);
+
+        if (count($posts)) {
+          Cache::add($element->getDataCacheKey(), $posts, $element->getCacheMinutes());
+          Cache::forever($element->getFallbackCacheKey(), $posts);
+          Cache::add($element->getRefreshCacheKey(), Carbon::now()->addSeconds($element->getCacheMinutes() * .8 * 60), $element->getCacheMinutes());
+        }
+      }
+    }
+  }
+
+  /**
+   * @param $feedUrl
+   * @param $itemCount
+   * @return array
+   */
+  protected function getFeedData($feedUrl, $itemCount) {
+    $posts = [];
+
+    try {
+      $content = file_get_contents($feedUrl);
+      $x = new SimpleXmlElement($content);
+      $posts = array();
+
+      for ($i = 0; $i < $itemCount; $i++) {
+        $post = $x->channel->item[$i];
+        $postData = array(
+          'link' => (string)$post->link,
+          'title' => (string)$post->title,
+          'description' => (string)$post->description
+        );
+        $posts[] = $postData;
+      }
+    } catch(\Exception $e) {
+      Log::error("Failed to fetch RSS feed: $feedUrl ($itemCount items)", ['exception' => $e]);
+    }
+    return $posts;
+  }
+}

--- a/plugins/castiron/staticmicrosite/Plugin.php
+++ b/plugins/castiron/staticmicrosite/Plugin.php
@@ -1,6 +1,7 @@
 <?php namespace Castiron\StaticMicrosite;
 
 use Backend;
+use Castiron\Manifold\Console\FetchRss;
 use System\Classes\PluginBase;
 use Castiron\StaticMicrosite\Models\RouteSettings;
 
@@ -31,7 +32,7 @@ class Plugin extends PluginBase
      */
     public function register()
     {
-
+      $this->registerConsoleCommand('rss.fetch', FetchRss::class);
     }
 
     /**


### PR DESCRIPTION
Implements Rss Feed Blog Posts as a content element where you specify the site url (http://blog.manifoldapp.org), the feed url (http://blog.manifoldapp.org/feed/), and how many posts you want (3 for the time being).  In the Content Element model we look to grab the posts from the Cache if present and if not we save to the Cache and store for an hour so they're available on the next page load.  Includes HTML comments in the markup to indicate whether the blog posts are coming from the cache or not.