### PR TITLE
[C] Set mysql to v5.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 /.idea
 /idea
 
+# Exclude Brewfile.lock since it is machine dependent
+Brewfile.lock.json
+
 # Ignore everything in the public dir with some whitelist
 /www/*
 !/www/favicon.ico

--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,6 @@
 brew "imagemagick"
 brew "composer"
-brew "mysql", restart_service: :changed
+brew "mysql@5.7", restart_service: :changed
 brew "nginx", restart_service: :changed
 brew "rbenv"
 brew "phpenv"

--- a/script/setup
+++ b/script/setup
@@ -25,7 +25,7 @@ if ! [ -f ".env" ]; then
 fi
 
 echo "===> Ensuring MySQL is running."
-brew services start mysql
+brew services start mysql@5.7
 
 db="${PROJ_NAME//-/_}_dev"
 if mysql -uroot "${db}" >/dev/null 2>&1 </dev/null


### PR DESCRIPTION
Nearly every project at Cast Iron Coding uses MySQL v5.7. Those that do not specify v5.7 are done in error. This PR is part of the correction process to standardize the MySQL version so multiple versions of MySQL do not fight with each other on developer machines.

I have not tested these changes locally, so if you have the project set up already, it might be worth starting it up to see if everything still works alright.